### PR TITLE
Add verbose debug-level logging and a bug fix for policy keys.

### DIFF
--- a/policies_test.go
+++ b/policies_test.go
@@ -26,12 +26,12 @@ func TestParsing(t *testing.T) {
 	}
 
 	expected := map[string]Conditions{
-		"HelloRequest.name": Conditions{
+		"HelloRequest.Name": Conditions{
 			CopyConditions:   &[]ConditionStatement{{Allowed: true, If: "HelloRequest.GetName < main.main"}},
 			PrintConditions:  &[]ConditionStatement{},
 			ModifyConditions: nil,
 		},
-		"HelloReply.message": Conditions{
+		"HelloReply.Message": Conditions{
 			CopyConditions:   nil,
 			PrintConditions:  nil,
 			ModifyConditions: nil,


### PR DESCRIPTION
In order to provide full inspection of the behaviour of this module,
I've added log lines that can be activated by

```
import (
    log "github.com/sirupsen/logrus"
)
```

and then putting this statement wherever you need logging to start from:

```
log.SetLevel(log.DebugLevel)
```

An example of the detail debug-level logging provides:
```
~/workspace/grpc-go/examples/helloworld/greeter_server on  master [!] via go v1.15.3 took 17m48s
❯ GRPC_PRIVACY_POLICY_LOCATION=./privacy_policy.json go run .
DEBU[0006] Received HelloRequest, name, 2, [github.com/CSCI-2390-Project/privacy-go.getStackTrace github.com/CSCI-2390-Project/privacy-go.recursiveCrypt.func1 google.golang.org/protobuf/internal/impl.(*messageState).Range github.com/CSCI-2390-Project/privacy-go.recursiveCrypt github.com/CSCI-2390-Project/privacy-go.PermissionedRecursiveDecrypt google.golang.org/grpc/examples/helloworld/helloworld.(*HelloRequest).String fmt.(*pp).handleMethods fmt.(*pp).printArg fmt.(*pp).doPrintf fmt.Sprintf github.com/sirupsen/logrus.(*Entry).Logf github.com/sirupsen/logrus.(*Entry).Infof github.com/sirupsen/logrus.(*Entry).Printf github.com/sirupsen/logrus.(*Logger).Printf github.com/sirupsen/logrus.Printf main.unsafeLogger main.(*server).SayHello google.golang.org/grpc/examples/helloworld/helloworld._Greeter_SayHello_Handler google.golang.org/grpc.(*Server).processUnaryRPC google.golang.org/grpc.(*Server).handleStream google.golang.org/grpc.(*Server).serveStreams.func1.2]
DEBU[0006] Policies file was parsed as map[HelloRequest.Name:{CopyConditions:<nil> PrintConditions:0xc0000ae900 ModifyConditions:<nil>}]
DEBU[0006] Converting HelloRequest, name to HelloRequest.Name
DEBU[0006] Found all conditions for HelloRequest.Name: {CopyConditions:<nil> PrintConditions:0xc0000ae900 ModifyConditions:<nil>}
DEBU[0006] Because HelloRequest.Name was chosen for action, using specific condition for that action: &[{Allowed:false If:main.unsafeLogger}]
DEBU[0006] Considering {Allowed:false If:main.unsafeLogger}
DEBU[0006] Accepted {Allowed:false If:main.unsafeLogger}
INFO[0006] <unsafeLogger> Hehe, I am going to do mischief with this value: name:"gAAAAABfv9UQIWD1-1I_uCH9rAHHGZbe5I63LKRPfYHLPn2QI5ZHd6l1_kXkVpzYMALdqwrb1rCQ1gDbe9F3mwxppnO_KtiHsdCDoNYTvA3DeCmRsno5t0Y="
DEBU[0006] Received HelloRequest, Name, 0, [github.com/CSCI-2390-Project/privacy-go.getStackTrace github.com/CSCI-2390-Project/privacy-go.PermissionedDecrypt google.golang.org/grpc/examples/helloworld/helloworld.(*HelloRequest).GetName main.(*server).SayHello google.golang.org/grpc/examples/helloworld/helloworld._Greeter_SayHello_Handler google.golang.org/grpc.(*Server).processUnaryRPC google.golang.org/grpc.(*Server).handleStream google.golang.org/grpc.(*Server).serveStreams.func1.2]
DEBU[0006] Policies file was parsed as map[HelloRequest.Name:{CopyConditions:<nil> PrintConditions:0xc0000ae900 ModifyConditions:<nil>}]
DEBU[0006] Converting HelloRequest, Name to HelloRequest.Name
DEBU[0006] Found all conditions for HelloRequest.Name: {CopyConditions:<nil> PrintConditions:0xc0000ae900 ModifyConditions:<nil>}
DEBU[0006] Because HelloRequest.Name was chosen for action, using specific condition for that action: <nil>
INFO[0006] This is the value we are computing in our SayHello function: Hello <some really sensitive data>
```

I also applied a fix for a pernicious bug that broke `Printing` actions.
Currently, our policy file is parsed assuming the provided string case for each
`Message` and `Field` is capitalized on invocation. It turns out this is
violated by `protoreflect.FieldDescriptor.Name()` which can return a
lowercase name for `Field`. To fix this, I patched our parsing logic and
`isActionAllowed` to convert all received strings into capitalized form.